### PR TITLE
Adiciona import de configuração do Reactotron ao snippet create-store…

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -153,6 +153,8 @@
       "import { createStore, compose, applyMiddleware } from 'redux';",
       "import createSagaMiddleware from 'redux-saga';",
       "",
+      "// import '../config/ReactotronConfig.js'; // Faça a importação do ReactotronConfig de acordo com seu projeto",
+      "",
       "import reducers from './ducks';",
       "import sagas from './sagas';",
       "",


### PR DESCRIPTION
Percebi que faltava indicar que deveria ser importado o arquivo de configuração do reactotron no index.js da Store (snippet create-store-react).
Coloquei uma linha comentada com este import e um comentário para a pessoa fazer a correção adequadamente de acordo com seu projeto.