### PR TITLE
feat: Add the console.tron.log snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Abaixo segue a lista com todos os Snippets disponíveis e os gatilhos para cada 
 |                 `rsduck →` | Cria um Duck com **Reduxsauce**                                               |
 |       `reactotron-react →` | Cria arquivo de configuração do **Reactotron**                                |
 | `reactotron-redux-react →` | Cria arquivo de configuração do **Reactotron** com **Redux** + **Redux Saga** |
+|                   `tron →` | Adiciona um `console.tron.log`, para utilizadores do **Reactotron** |
 
 <!-- CONTRIBUTING -->
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ Abaixo segue a lista com todos os Snippets disponíveis e os gatilhos para cada 
 |                 `rsduck →` | Cria um Duck com **Reduxsauce**                                               |
 |       `reactotron-react →` | Cria arquivo de configuração do **Reactotron**                                |
 | `reactotron-redux-react →` | Cria arquivo de configuração do **Reactotron** com **Redux** + **Redux Saga** |
-|                   `tron →` | Adiciona um `console.tron.log`, para utilizadores do **Reactotron** |
+|                    `ctl →` | Adiciona um `console.tron.log`, para utilizadores do **Reactotron**           |
+|                    `ctw →` | Adiciona um `console.tron.warn`, para utilizadores do **Reactotron**          |
+|                    `cte →` | Adiciona um `console.tron.error`, para utilizadores do **Reactotron**         |
 
 <!-- CONTRIBUTING -->
 

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -305,5 +305,11 @@
       ""
     ],
     "description": "Create ReactJS Reactotron Config with Redux and Redux Saga"
+  },
+
+  "reactotronConsole": {
+    "prefix": "tron",
+    "body": ["console.tron.log('$1');", "$2"],
+    "description": "Useful and Fast way to add a console.tron.log and continue your proccess"
   }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -307,9 +307,30 @@
     "description": "Create ReactJS Reactotron Config with Redux and Redux Saga"
   },
 
-  "reactotronConsole": {
-    "prefix": "tron",
-    "body": ["console.tron.log('$1');", "$2"],
+  "reactotronConsoleLog": {
+    "prefix": "ctl",
+    "body": [
+      "console.tron.log('$1');",
+      ""
+    ],
     "description": "Useful and Fast way to add a console.tron.log and continue your proccess"
+  },
+
+  "reactotronConsoleWarn": {
+    "prefix": "ctw",
+    "body": [
+      "console.tron.warn('$1');",
+      ""
+    ],
+    "description": "Useful and Fast way to add a console.tron.warn and continue your proccess"
+  },
+
+  "reactotronConsoleError": {
+    "prefix": "cte",
+    "body": [
+      "console.tron.error('$1');",
+      ""
+    ],
+    "description": "Useful and Fast way to add a console.tron.error and continue your proccess"
   }
 }


### PR DESCRIPTION
When we are in the development process, we use some consoles to debug,
and recently, thanks to Reactotron, we are using the console.tron.log.
So I use one snippet to add the console faster. Until this point, I use
`ctl` in my local machine, but I guess the `tron` should be easier to
understand.