### PR TITLE
feat: Add some Saga Effects and Redux Snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Abaixo segue a lista com todos os Snippets disponíveis e os gatilhos para cada 
 |                    `api →` | Cria um arquivo de configuração do Axios                                      |
 |        `mapstatetoprops →` | Cria o método `mapStateToProps` vazio                                         |
 |     `mapdispatchtoprops →` | Cria o método `mapDispatchToProps` vazio                                      |
+|          `redux-connect →` | Cria todos métodos de conexão do redux em um componente                       |
+|          `redux-imports →` | Adiciona as importações do Redux                                              |
 |     `create-store-react →` | Cria o arquivo de configuração do Redux, combinando os Ducks com os Sagas     |
 |           `root-reducer →` | Cria o arquivo que combina os Reducers                                        |
 |              `root-saga →` | Cria o arquivo que centraliza os Sagas                                        |
@@ -82,6 +84,10 @@ Abaixo segue a lista com todos os Snippets disponíveis e os gatilhos para cada 
 |                 `rsduck →` | Cria um Duck com **Reduxsauce**                                               |
 |       `reactotron-react →` | Cria arquivo de configuração do **Reactotron**                                |
 | `reactotron-redux-react →` | Cria arquivo de configuração do **Reactotron** com **Redux** + **Redux Saga** |
+|                `yselect →` | Adiciona o `select effect` do **Redux Sagas** de maneira ágil                 |
+|                   `yput →` | Adiciona o `put effect` do **Redux Sagas** de maneira ágil                    |
+|                  `ycall →` | Adiciona o `call effect` do **Redux Sagas** de maneira ágil                   |
+|                   `yall →` | Adiciona o `all effect` do **Redux Sagas** de maneira ágil                    |
 
 <!-- CONTRIBUTING -->
 

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -147,6 +147,34 @@
     "description": "Create Redux method mapDispatchToProps"
   },
 
+  "reduxConnect": {
+    "prefix": "redux-connect",
+    "body": [
+      "const mapStateToProps = ({ $1Reducer }) => ({",
+      "  $2: $1Reducer.$2",
+      "})",
+
+      "const mapDispatchToProps = dispatch =>",
+      "  bindActionCreators($1Actions, dispatch);",
+
+      "export default connect(",
+      "  mapStateToProps,",
+      "  mapDispatchToProps",
+      ")($3)",
+      ""
+    ]
+  },
+
+  "reduxImports": {
+    "prefix": "redux-imports",
+    "body": [
+      "import { connect } from 'react-redux'",
+      "import { bindActionCreators } from 'redux'",
+      "import $1 from '$2'",
+      ""
+    ]
+  },
+
   "createStore": {
     "prefix": "create-store-react",
     "body": [
@@ -305,5 +333,43 @@
       ""
     ],
     "description": "Create ReactJS Reactotron Config with Redux and Redux Saga"
+  },
+
+  "selectReduxSagaEffects": {
+    "prefix": "yselect",
+    "body": [
+      "const { $1 } = yield select(( $2 ) => $2$3);",
+      ""
+    ],
+    "description": "Easily add a select effect from Redux Sagas"
+  },
+
+  "putReduxSagaEffects": {
+    "prefix": "yput",
+    "body": [
+      "yield put($1Actions.$2());",
+      ""
+    ],
+    "description": "Easily add a put effect from Redux Sagas"
+  },
+
+  "callReduxSagaEffects": {
+    "prefix": "ycall",
+    "body": [
+      "yield call($1, $2)",
+      ""
+    ],
+    "description": "Easily add a call effect from Redux Sagas"
+  },
+
+  "allReduxSagaEffects": {
+    "prefix": "yall",
+    "body": [
+      "yield all([",
+      "  $1",
+      "]);",
+      ""
+    ],
+    "description": "Easily add an all effect from Redux Sagas"
   }
 }


### PR DESCRIPTION
When we use Redux in our app, we frequently use some code blocks, like
import the redux connect and dispatch, and link the component with
Redux. When we pass to use Sagas, more codes are added to list, calling
some effects with the yield method. So I created some personal snippets
to make those things fasters

Maybe it don't be really useful to you, but I frequently use those, and maybe someone else also does that.