### PR TITLE
remove standard export

### DIFF
--- a/snippets/snippets-ts.json
+++ b/snippets/snippets-ts.json
@@ -15,16 +15,13 @@
   "componentFunctionalTypescript": {
     "prefix": "rfc",
     "body": [
-      "import React from 'react';",
-      "",
       "// import { Container } from './styles';",
       "",
-      "const ${1:${TM_DIRECTORY/^.*(\\/|\\\\)([^(\\/|\\\\)]+)$/$2/}}: React.FC = () => {",
+      "export function ${1:${TM_DIRECTORY/^.*(\\/|\\\\)([^(\\/|\\\\)]+)$/$2/}}() {",
       "  return <div />;",
       "}",
-      "",
-      "export default ${1:${TM_DIRECTORY/^.*(\\/|\\\\)([^(\\/|\\\\)]+)$/$2/}};"
+      ""
     ],
     "description": "Create ReactJS Functional Component Typescript"
-  }	
+  }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -15,16 +15,13 @@
   "componentFunctionalTypescript": {
     "prefix": "rfc",
     "body": [
-      "import React from 'react';",
-      "",
       "// import { Container } from './styles';",
       "",
-      "function ${1:${TM_DIRECTORY/^.*(\\/|\\\\)([^(\\/|\\\\)]+)$/$2/}}() {",
+      "export function ${1:${TM_DIRECTORY/^.*(\\/|\\\\)([^(\\/|\\\\)]+)$/$2/}}() {",
       "  return <div />;",
       "}",
-      "",
-      "export default ${1:${TM_DIRECTORY/^.*(\\/|\\\\)([^(\\/|\\\\)]+)$/$2/}};"
+      ""
     ],
     "description": "Create ReactJS Functional Component Typescript"
-  }	
+  }
 }


### PR DESCRIPTION
What problem is this solving?

Remove standard export.

How to test it?

run the rfc snippet on a JS / TS / TSX file.

Screenshots or example usage:

Before:
![before](https://user-images.githubusercontent.com/42042836/113524005-1ecd7300-9582-11eb-9aaa-bbeb893a9e71.gif)

After:
![after](https://user-images.githubusercontent.com/42042836/113524013-2e4cbc00-9582-11eb-8015-e7375a26fbbb.gif)

